### PR TITLE
Monitor de la batería

### DIFF
--- a/Code/BatteryReading/BatteryReading.ino
+++ b/Code/BatteryReading/BatteryReading.ino
@@ -1,0 +1,28 @@
+/// PINS ///
+const int batteryPin = A5;
+
+/// CONSTANTS ///
+const float voltageBattCharged = 12.35;
+
+/// VARIABLES ///
+float voltage = 0;
+
+float readBattery(int batt_input)
+{
+  int readInput;
+  float batt_voltage;
+  readInput = analogRead(batt_input);
+  batt_voltage = (((readInput*4.9)/1000)*voltageBattCharged)/4.81;
+  return batt_voltage;
+}
+
+void setup() {
+  pinMode(batteryPin, INPUT);
+  Serial.begin(9600);
+}
+
+void loop() {
+  voltage = readBattery(batteryPin);
+  Serial.println(voltage);
+  delay(1000);
+}


### PR DESCRIPTION
Hará falta calibrar al momento de implementar en el circuito final.

Es importante ajustar una de las impedancias del divisor de voltaje con un potenciómetro.